### PR TITLE
Add naucse_render dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,7 +18,7 @@ mistune = "*"
 nbconvert = "*"
 python-dateutil = "*"
 traitlets = "*"
-arca = {extras = ["docker"], version = ">= 0.3"}
+arca = {extras = ["docker"],version = ">= 0.3"}
 cssutils = "*"
 click = "*"
 giturlparse = "*"
@@ -30,6 +30,7 @@ jupyter_client = "*"
 Pygments = "*"
 Werkzeug = "*"
 GitPython = "*"
+naucse-render = "<1.0"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3f26acd9cabc637d3021619621b28dfeffee3059675f3e2c68389a0a41e2efd2"
+            "sha256": "5cb4a19cb422e8713b24586deec37ee8bea32644329ca83cbb839b8df90611c9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -270,6 +270,14 @@
             ],
             "index": "pypi",
             "version": "==0.8.3"
+        },
+        "naucse-render": {
+            "hashes": [
+                "sha256:38730174ab499182a0a915c210060fceaa0be49ced88677e50865d6365ef9d34",
+                "sha256:66a36b29141d37398a2608e1f9718e850bc36908d1aae653531906b039b3ad58"
+            ],
+            "index": "pypi",
+            "version": "==0.1"
         },
         "nbconvert": {
             "hashes": [


### PR DESCRIPTION
We're making changes to naucse and need to add `naucse_render` to this fork.
(See https://github.com/pyvec/naucse.python.cz/issues/494 and https://github.com/pyvec/naucse.python.cz/pull/505 for all the details.)
